### PR TITLE
Fixed TVL not showing on monitors with less than 1440px horizontal

### DIFF
--- a/src/pages/Explorer/components/Deposit/desktop/DesktopTable.tsx
+++ b/src/pages/Explorer/components/Deposit/desktop/DesktopTable.tsx
@@ -74,8 +74,9 @@ const DesktopTable = (props: IDepositTable) => {
       {!C3Address && totalValueLocked && (
         <S.Footer>
           <S.TVLContainer item desktop={10}>
-            <S.TVLLabel>Total Value Locked (</S.TVLLabel>TVL
-            <S.TVLLabel>): ${formatNumber(totalValueLocked)}</S.TVLLabel>
+            <S.TVLLabelFullForm>Total Value Locked (</S.TVLLabelFullForm>TVL
+            <S.TVLLabelFullForm>)</S.TVLLabelFullForm>
+            <S.TVLLabel>: ${formatNumber(totalValueLocked)}</S.TVLLabel>
             <TooltipInfo message="The total value of all available assets inside the C3 exchange platform." />
           </S.TVLContainer>
         </S.Footer>

--- a/src/pages/Explorer/components/Deposit/desktop/DesktopTable.tsx
+++ b/src/pages/Explorer/components/Deposit/desktop/DesktopTable.tsx
@@ -74,9 +74,10 @@ const DesktopTable = (props: IDepositTable) => {
       {!C3Address && totalValueLocked && (
         <S.Footer>
           <S.TVLContainer item desktop={10}>
-            <S.TVLLabelFullForm>Total Value Locked (</S.TVLLabelFullForm>TVL
-            <S.TVLLabelFullForm>)</S.TVLLabelFullForm>
-            <S.TVLLabel>: ${formatNumber(totalValueLocked)}</S.TVLLabel>
+            <S.TVLLabel _isFullForm>Total Value Locked (</S.TVLLabel>
+            <S.TVLLabel>TVL</S.TVLLabel>
+            <S.TVLLabel _isFullForm>)</S.TVLLabel>
+            <S.TVLLabel _isUSDValue>: ${formatNumber(totalValueLocked)}</S.TVLLabel>
             <TooltipInfo message="The total value of all available assets inside the C3 exchange platform." />
           </S.TVLContainer>
         </S.Footer>

--- a/src/pages/Explorer/components/Deposit/desktop/styles.ts
+++ b/src/pages/Explorer/components/Deposit/desktop/styles.ts
@@ -100,11 +100,9 @@ export const TVLLabel = styled('span', {
 })<ITVLLabel>(({ theme, _isFullForm, _isUSDValue }) => ({
   display: 'inline-block',
   fontWeight: _isUSDValue ? 700 : _isFullForm ? 600 : 400,
-  ...(_isFullForm && {
-    [theme.breakpoints.down('largeDesktop')]: {
-      display: 'none',
-    },
-  }),
+  [theme.breakpoints.down('largeDesktop')]: {
+    display: _isFullForm ? 'none' : 'visible',
+  },
 }));
 
 export const RightAlignedGrid = styled(Grid)(({ theme }) => ({

--- a/src/pages/Explorer/components/Deposit/desktop/styles.ts
+++ b/src/pages/Explorer/components/Deposit/desktop/styles.ts
@@ -1,5 +1,11 @@
 import Grid from '@mui/material/Grid';
 import styled from '@mui/material/styles/styled';
+import { createShouldForwardProp } from '../../../../../utils';
+
+export interface ITVLLabel {
+  _isFullForm?: boolean;
+  _isUSDValue?: boolean;
+}
 
 export const Container = styled(Grid)(({ theme }) => ({
   fontFamily: 'Manrope',
@@ -89,17 +95,16 @@ export const TVLContainer = styled(Grid)(({ theme }) => ({
   margin: '0px 0px 0px 22px',
 }));
 
-export const TVLLabelFullForm = styled('span')(({ theme }) => ({
+export const TVLLabel = styled('span', {
+  shouldForwardProp: createShouldForwardProp(['_isFullForm', '_isUSDValue']),
+})<ITVLLabel>(({ theme, _isFullForm, _isUSDValue }) => ({
   display: 'inline-block',
-  fontWeight: 600,
-  [theme.breakpoints.down('largeDesktop')]: {
-    display: 'none',
-  },
-}));
-
-export const TVLLabel = styled('span')(({ theme }) => ({
-  display: 'inline-block',
-  fontWeight: 700,
+  fontWeight: _isUSDValue ? 700 : _isFullForm ? 600 : 400,
+  ...(_isFullForm && {
+    [theme.breakpoints.down('largeDesktop')]: {
+      display: 'none',
+    },
+  }),
 }));
 
 export const RightAlignedGrid = styled(Grid)(({ theme }) => ({

--- a/src/pages/Explorer/components/Deposit/desktop/styles.ts
+++ b/src/pages/Explorer/components/Deposit/desktop/styles.ts
@@ -89,12 +89,17 @@ export const TVLContainer = styled(Grid)(({ theme }) => ({
   margin: '0px 0px 0px 22px',
 }));
 
-export const TVLLabel = styled('span')(({ theme }) => ({
+export const TVLLabelFullForm = styled('span')(({ theme }) => ({
   display: 'inline-block',
   fontWeight: 600,
   [theme.breakpoints.down('largeDesktop')]: {
     display: 'none',
   },
+}));
+
+export const TVLLabel = styled('span')(({ theme }) => ({
+  display: 'inline-block',
+  fontWeight: 700,
 }));
 
 export const RightAlignedGrid = styled(Grid)(({ theme }) => ({


### PR DESCRIPTION
Changed a media query that made the TVL Label not appearing in monitors under 1440px.
Now it shows the abbreviated version in those smaller monitors.