### PR TITLE
Fixed search result address changing when the user is writing a new search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "buffer": "^6.0.3",
+        "cross-env": "^7.0.3",
         "crypto-browserify": "^3.12.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-config-react-app": "^7.0.1",
@@ -8179,6 +8180,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "PORT=4172 react-app-rewired start",
-    "start-windows": "set PORT=4172 && react-app-rewired start",
+    "start": "cross-env PORT=4172 react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
@@ -59,6 +58,7 @@
   "homepage": "https://scan.c3.io/",
   "devDependencies": {
     "buffer": "^6.0.3",
+    "cross-env": "^7.0.3",
     "crypto-browserify": "^3.12.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-react-app": "^7.0.1",

--- a/src/pages/Explorer/Explorer.tsx
+++ b/src/pages/Explorer/Explorer.tsx
@@ -40,12 +40,21 @@ const Explorer = () => {
 
   const onClear = () => {
     setAddress('');
-    setC3Address('');
     setWrongAddress(false);
+  };
+
+  const onReturnHomePage = () => {
+    onClear();
+    setC3Address('');
   };
 
   const onCopy = async (address: string) => {
     copy(address);
+  };
+
+  const onChangeAddress = (adrInput: string) => {
+    setAddress(adrInput);
+    setWrongAddress(false);
   };
 
   const onSearch = () => {
@@ -61,8 +70,12 @@ const Explorer = () => {
 
   const path = useMemo(() => {
     const values: IPath[] = [
-      { text: 'Explorer', route: AppRoutes.EXPLORER, onClick: () => onClear() },
-      { text: 'C3 Overview', route: AppRoutes.EXPLORER, onClick: () => onClear() },
+      { text: 'Explorer', route: AppRoutes.EXPLORER, onClick: () => onReturnHomePage() },
+      {
+        text: 'C3 Overview',
+        route: AppRoutes.EXPLORER,
+        onClick: () => onReturnHomePage(),
+      },
     ];
     if (C3Address) values.push({ text: 'Search result' });
     return values;
@@ -77,7 +90,7 @@ const Explorer = () => {
           address={address}
           onSearch={onSearch}
           onClear={onClear}
-          onChangeAddress={setAddress}
+          onChangeAddress={onChangeAddress}
           hasC3Address={!!C3Address}
         />
       </Grid>

--- a/src/pages/Explorer/components/Deposit/desktop/DesktopTable.tsx
+++ b/src/pages/Explorer/components/Deposit/desktop/DesktopTable.tsx
@@ -74,8 +74,10 @@ const DesktopTable = (props: IDepositTable) => {
       {!C3Address && totalValueLocked && (
         <S.Footer>
           <S.TVLContainer item desktop={10}>
-            <S.TVLLabel>Total Value Locked (</S.TVLLabel>TVL
-            <S.TVLLabel>): ${formatNumber(totalValueLocked)}</S.TVLLabel>
+            <S.TVLLabel _isFullForm>Total Value Locked (</S.TVLLabel>
+            <S.TVLLabel>TVL</S.TVLLabel>
+            <S.TVLLabel _isFullForm>)</S.TVLLabel>
+            <S.TVLLabel _isUSDValue>: ${formatNumber(totalValueLocked)}</S.TVLLabel>
             <TooltipInfo message="The total value of all available assets inside the C3 exchange platform." />
           </S.TVLContainer>
         </S.Footer>

--- a/src/pages/Explorer/components/Deposit/desktop/styles.ts
+++ b/src/pages/Explorer/components/Deposit/desktop/styles.ts
@@ -1,5 +1,11 @@
 import Grid from '@mui/material/Grid';
 import styled from '@mui/material/styles/styled';
+import { createShouldForwardProp } from '../../../../../utils';
+
+export interface ITVLLabel {
+  _isFullForm?: boolean;
+  _isUSDValue?: boolean;
+}
 
 export const Container = styled(Grid)(({ theme }) => ({
   fontFamily: 'Manrope',
@@ -89,11 +95,13 @@ export const TVLContainer = styled(Grid)(({ theme }) => ({
   margin: '0px 0px 0px 22px',
 }));
 
-export const TVLLabel = styled('span')(({ theme }) => ({
+export const TVLLabel = styled('span', {
+  shouldForwardProp: createShouldForwardProp(['_isFullForm', '_isUSDValue']),
+})<ITVLLabel>(({ theme, _isFullForm, _isUSDValue }) => ({
   display: 'inline-block',
-  fontWeight: 600,
+  fontWeight: _isUSDValue ? 700 : _isFullForm ? 600 : 400,
   [theme.breakpoints.down('largeDesktop')]: {
-    display: 'none',
+    display: _isFullForm ? 'none' : 'visible',
   },
 }));
 

--- a/src/pages/Explorer/components/Hero/Hero.tsx
+++ b/src/pages/Explorer/components/Hero/Hero.tsx
@@ -30,8 +30,19 @@ const Hero = ({
     [windowSize.width]
   );
 
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      onSearch();
+    }
+  };
+
   return (
-    <S.Container container direction="column" _hasC3Address={hasC3Address}>
+    <S.Container
+      container
+      direction="column"
+      _hasC3Address={hasC3Address}
+      onKeyUp={handleKeyPress}
+    >
       <Grid container>
         <S.Title _hasC3Address={hasC3Address}>
           Search C3 data directly from the Blockchain

--- a/src/pages/Explorer/components/Hero/Hero.tsx
+++ b/src/pages/Explorer/components/Hero/Hero.tsx
@@ -31,7 +31,7 @@ const Hero = ({
   );
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
+    if (!wrongAddress && event.key === 'Enter') {
       onSearch();
     }
   };


### PR DESCRIPTION
Before, for searching a new address you had to clear the input and the previous result.
Now thats reworked so clearing the input doesn't erase the result. And the only way to go back to the C3 Overview page is by clicking the paths breadcrumb.

Also when the inputted address is incorrect, before you had to clear the input to be able to search again. Now you just have to edit the address in the input and the search button unlocks.