### PR TITLE
Fixed expireDate from decoded Settle messages

### DIFF
--- a/src/pages/Decoder/components/DecodedInfo/DecodedInfo.tsx
+++ b/src/pages/Decoder/components/DecodedInfo/DecodedInfo.tsx
@@ -1,4 +1,3 @@
-import Grid from '@mui/material/Grid';
 import { DecodedMessage } from '../../../../interfaces/interfaces';
 import { keyToLabelMapping } from '../../../../utils';
 import * as S from './styles';
@@ -16,8 +15,8 @@ const DecodedInfo = ({ decodedMsg }: IDecodedInfo) => {
           const label = keyToLabelMapping[key as keyof DecodedMessage] || key;
           return (
             <S.Row justifyContent="space-between">
-              <Grid item>{label}:</Grid>
-              <Grid item>{value}</Grid>
+              <S.Label item>{label}:</S.Label>
+              <S.Value item>{value}</S.Value>
             </S.Row>
           );
         })}

--- a/src/pages/Decoder/components/DecodedInfo/styles.ts
+++ b/src/pages/Decoder/components/DecodedInfo/styles.ts
@@ -31,3 +31,14 @@ export const Row = styled(Grid)(({ theme }) => ({
   paddingLeft: '10px',
   paddingRight: '10px',
 }));
+
+export const Label = styled(Grid)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: '14px',
+}));
+
+export const Value = styled(Grid)(({ theme }) => ({
+  color: theme.palette.primary.contrastText,
+  fontWeight: 500,
+  fontSize: '14px',
+}));

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -12,6 +12,7 @@ import {
   ServerInstrument,
   convertUint64toInt64,
 } from '@c3exchange/common';
+import { dateToCustomStrFormat } from './utils';
 
 export const withdrawFormat = '(byte,uint8,uint64,(uint16,address),uint64,uint64)';
 export const poolMoveFormat = '(byte,uint8,uint64)';
@@ -90,7 +91,7 @@ const decodeWelcomeMessage = (encodedMessage: string) => {
   if (parts.length < 2) return;
   const userID = parts[0];
   const extractedCreationTime = parts[1];
-  const creationTime = new Date(parseInt(extractedCreationTime)).toISOString();
+  const creationTime = dateToCustomStrFormat(new Date(parseInt(extractedCreationTime)));
   const operationType = getEnumKeyByEnumValue(OnChainRequestOp, OnChainRequestOp.Login);
   return { operationType, userID, creationTime };
 };
@@ -181,6 +182,7 @@ function decodeWithdraw(operation: Uint8Array, appState: ServerInstrument[]) {
   const instrumentName = getInstrumentfromSlotId(instrumentSlotId, appState).id;
   return { operationType, instrumentName, amount };
 }
+
 function decodePoolMove(operation: Uint8Array, appState: ServerInstrument[]) {
   const poolResult = decodeABIValue(operation, poolMoveFormat);
   const instrumentSlotId = Number(poolResult[1]);
@@ -199,11 +201,12 @@ function decodePoolMove(operation: Uint8Array, appState: ServerInstrument[]) {
   const instrumentName = getInstrumentfromSlotId(instrumentSlotId, appState).id;
   return { operationType, instrumentName, amount };
 }
+
 function decodeSettle(operation: Uint8Array, appState: ServerInstrument[]) {
   const settleResult = decodeABIValue(operation, settleFormat);
   const operationType = getEnumKeyByEnumValue(OnChainRequestOp, OnChainRequestOp.Settle);
   const nonce = Number(settleResult[2]);
-  const expiresOn = new Date(parseInt(settleResult[3])).toISOString();
+  const expiresOn = dateToCustomStrFormat(new Date(parseInt(settleResult[3]) * 1000));
   const sellSlotId = settleResult[4];
   const sellAsset = getInstrumentfromSlotId(sellSlotId, appState);
   const sellAmount = Number(
@@ -277,7 +280,7 @@ export const keyToLabelMapping: { [key in keyof DecodedMessage]?: string } = {
   userID: 'User ID',
   creationTime: 'Creation Time',
   account: 'Account',
-  expiresOn: 'Expires on',
+  expiresOn: 'Expiration Time',
   buyAmount: 'Buy Amount',
   buyAssetId: 'Buy Asset',
   maxBorrow: 'Max Borrow',

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -12,7 +12,6 @@ import {
   ServerInstrument,
   convertUint64toInt64,
 } from '@c3exchange/common';
-import { dateToCustomStrFormat } from './utils';
 
 export const withdrawFormat = '(byte,uint8,uint64,(uint16,address),uint64,uint64)';
 export const poolMoveFormat = '(byte,uint8,uint64)';
@@ -91,7 +90,7 @@ const decodeWelcomeMessage = (encodedMessage: string) => {
   if (parts.length < 2) return;
   const userID = parts[0];
   const extractedCreationTime = parts[1];
-  const creationTime = dateToCustomStrFormat(new Date(parseInt(extractedCreationTime)));
+  const creationTime = new Date(parseInt(extractedCreationTime)).toLocaleString();
   const operationType = getEnumKeyByEnumValue(OnChainRequestOp, OnChainRequestOp.Login);
   return { operationType, userID, creationTime };
 };
@@ -206,7 +205,7 @@ function decodeSettle(operation: Uint8Array, appState: ServerInstrument[]) {
   const settleResult = decodeABIValue(operation, settleFormat);
   const operationType = getEnumKeyByEnumValue(OnChainRequestOp, OnChainRequestOp.Settle);
   const nonce = Number(settleResult[2]);
-  const expiresOn = dateToCustomStrFormat(new Date(parseInt(settleResult[3]) * 1000));
+  const expiresOn = new Date(parseInt(settleResult[3]) * 1000).toLocaleString();
   const sellSlotId = settleResult[4];
   const sellAsset = getInstrumentfromSlotId(sellSlotId, appState);
   const sellAmount = Number(

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -39,3 +39,35 @@ export const truncateText = (text = '', [start, end]: number[] = [6, 6]) => {
   const tail = text.slice(-1 * end, text.length);
   return text.length > start + end ? [head, tail].join('...') : text;
 };
+
+const months = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+export const dateToCustomStrFormat = (date: Date): string => {
+  return (
+    String(date.getUTCDate()).padStart(2, '0') +
+    ' ' +
+    months[date.getUTCMonth()] +
+    ' ' +
+    date.getUTCFullYear() +
+    ' ' +
+    String(date.getUTCHours()).padStart(2, '0') +
+    ':' +
+    String(date.getUTCMinutes()).padStart(2, '0') +
+    ':' +
+    String(date.getUTCSeconds()).padStart(2, '0') +
+    ' UTC'
+  );
+};

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -39,35 +39,3 @@ export const truncateText = (text = '', [start, end]: number[] = [6, 6]) => {
   const tail = text.slice(-1 * end, text.length);
   return text.length > start + end ? [head, tail].join('...') : text;
 };
-
-const months = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
-
-export const dateToCustomStrFormat = (date: Date): string => {
-  return (
-    String(date.getUTCDate()).padStart(2, '0') +
-    ' ' +
-    months[date.getUTCMonth()] +
-    ' ' +
-    date.getUTCFullYear() +
-    ' ' +
-    String(date.getUTCHours()).padStart(2, '0') +
-    ':' +
-    String(date.getUTCMinutes()).padStart(2, '0') +
-    ':' +
-    String(date.getUTCSeconds()).padStart(2, '0') +
-    ' UTC'
-  );
-};


### PR DESCRIPTION
When decoding the expire date for Settle messages, the number symbolized seconds but the Date class from JS required milliseconds.
Also, updated the way the dates of decoded messages appeared. Now it shows corresponding the language configuration of the web browser.

The following image shows: a mock of sell BTC to get USDC (07/3/2024 15:19:03 Argentinian time):
![image](https://github.com/c3exchange/c3-scan/assets/158588059/6509a862-3292-47f5-abef-ef3edd96ab5c)
