### PR TITLE
Added chainId & chainName to Withdraw decoded messages

### DIFF
--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -33,6 +33,10 @@ export interface DecodedMessage {
   buyAssetId?: string;
   buyAmount?: number;
   maxRepay?: number;
+  chain?: {
+    chainId: number;
+    chainName: string;
+  };
 }
 
 export enum OnChainRequestOp {

--- a/src/pages/Decoder/components/DecodedInfo/DecodedInfo.tsx
+++ b/src/pages/Decoder/components/DecodedInfo/DecodedInfo.tsx
@@ -1,6 +1,6 @@
 import Grid from '@mui/material/Grid';
 import { DecodedMessage } from '../../../../interfaces/interfaces';
-import { keyToLabelMapping } from '../../../../utils';
+import { keyToLabelMapping, processValue } from '../../../../utils';
 import * as S from './styles';
 
 interface IDecodedInfo {
@@ -8,17 +8,12 @@ interface IDecodedInfo {
 }
 
 const DecodedInfo = ({ decodedMsg }: IDecodedInfo) => {
-  const processValue = (value: any) => {
-    let primaryValue = '';
-    let secondaryValue = '';
-    if (value?.chainId) {
-      primaryValue = value?.chainId;
-      secondaryValue = ' - ' + value?.chainName;
-    }
+  const formatValue = (value: any) => {
+    const { primaryValue, secondaryValue } = processValue(value);
     return (
       <>
         {primaryValue}
-        <S.SecondaryValue>{secondaryValue}</S.SecondaryValue>
+        {secondaryValue && <S.SecondaryValue>{secondaryValue}</S.SecondaryValue>}
       </>
     );
   };
@@ -32,7 +27,7 @@ const DecodedInfo = ({ decodedMsg }: IDecodedInfo) => {
           return (
             <S.Row justifyContent="space-between">
               <Grid item>{label}:</Grid>
-              <Grid item>{typeof value === 'object' ? processValue(value) : value}</Grid>
+              <Grid item>{formatValue(value)}</Grid>
             </S.Row>
           );
         })}

--- a/src/pages/Decoder/components/DecodedInfo/DecodedInfo.tsx
+++ b/src/pages/Decoder/components/DecodedInfo/DecodedInfo.tsx
@@ -8,6 +8,21 @@ interface IDecodedInfo {
 }
 
 const DecodedInfo = ({ decodedMsg }: IDecodedInfo) => {
+  const processValue = (value: any) => {
+    let primaryValue = '';
+    let secondaryValue = '';
+    if (value?.chainId) {
+      primaryValue = value?.chainId;
+      secondaryValue = ' - ' + value?.chainName;
+    }
+    return (
+      <>
+        {primaryValue}
+        <S.SecondaryValue>{secondaryValue}</S.SecondaryValue>
+      </>
+    );
+  };
+
   return (
     <S.Container container direction="column">
       <S.Title item>Translation (aka Parsed Text)</S.Title>
@@ -17,7 +32,7 @@ const DecodedInfo = ({ decodedMsg }: IDecodedInfo) => {
           return (
             <S.Row justifyContent="space-between">
               <Grid item>{label}:</Grid>
-              <Grid item>{value}</Grid>
+              <Grid item>{typeof value === 'object' ? processValue(value) : value}</Grid>
             </S.Row>
           );
         })}

--- a/src/pages/Decoder/components/DecodedInfo/styles.ts
+++ b/src/pages/Decoder/components/DecodedInfo/styles.ts
@@ -31,3 +31,9 @@ export const Row = styled(Grid)(({ theme }) => ({
   paddingLeft: '10px',
   paddingRight: '10px',
 }));
+
+export const SecondaryValue = styled('span')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontWeight: 300,
+  fontSize: '14px',
+}));

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -11,6 +11,8 @@ import {
   InstrumentAmount,
   ServerInstrument,
   convertUint64toInt64,
+  getChainNameByChainId,
+  ChainId,
 } from '@c3exchange/common';
 
 export const withdrawFormat = '(byte,uint8,uint64,(uint16,address),uint64,uint64)';
@@ -172,6 +174,9 @@ function decodeWithdraw(operation: Uint8Array, appState: ServerInstrument[]) {
   );
   const instrumentSlotId = Number(withdrawResult[1]);
   const encodedAmount = withdrawResult[2];
+  const chainId = Number(withdrawResult[3][0]);
+  const chainName = getChainNameByChainId(chainId as ChainId);
+  const chain = { chainId, chainName };
   const amount = Number(
     InstrumentAmount.fromContract(
       getInstrumentfromSlotId(instrumentSlotId, appState),
@@ -179,8 +184,9 @@ function decodeWithdraw(operation: Uint8Array, appState: ServerInstrument[]) {
     ).toDecimal()
   );
   const instrumentName = getInstrumentfromSlotId(instrumentSlotId, appState).id;
-  return { operationType, instrumentName, amount };
+  return { operationType, instrumentName, amount, chain };
 }
+
 function decodePoolMove(operation: Uint8Array, appState: ServerInstrument[]) {
   const poolResult = decodeABIValue(operation, poolMoveFormat);
   const instrumentSlotId = Number(poolResult[1]);
@@ -199,6 +205,7 @@ function decodePoolMove(operation: Uint8Array, appState: ServerInstrument[]) {
   const instrumentName = getInstrumentfromSlotId(instrumentSlotId, appState).id;
   return { operationType, instrumentName, amount };
 }
+
 function decodeSettle(operation: Uint8Array, appState: ServerInstrument[]) {
   const settleResult = decodeABIValue(operation, settleFormat);
   const operationType = getEnumKeyByEnumValue(OnChainRequestOp, OnChainRequestOp.Settle);
@@ -285,6 +292,7 @@ export const keyToLabelMapping: { [key in keyof DecodedMessage]?: string } = {
   nonce: 'Nonce',
   sellAmount: 'Sell Amount',
   sellAssetId: 'Sell Asset',
+  chain: 'Chain',
 };
 
 export const getFirstAndLastChars = (

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -311,3 +311,17 @@ export const getEnumKeyByEnumValue = (
   let keys = Object.keys(enumObj).filter((x) => enumObj[x] === enumValue);
   return keys.length > 0 ? keys[0] : undefined;
 };
+
+export const processValue = (value: any) => {
+  let primaryValue: string = '';
+  let secondaryValue: string = '';
+  if (value?.chainId) {
+    primaryValue = value?.chainId;
+    secondaryValue = ' - ' + value?.chainName;
+  } else if (typeof value === 'object') {
+    primaryValue = JSON.stringify(value);
+  } else {
+    primaryValue = value;
+  }
+  return { primaryValue, secondaryValue };
+};


### PR DESCRIPTION
When decoding a Withdraw message, now it also shows the Chain Id and Name.
Also added a way to show in the rows of decoded (key, value) a primary value in normal style, and a secondary value in a grayer/shaded style.

![image](https://github.com/c3exchange/c3-scan/assets/158588059/8b4677c0-cc83-4426-a59c-8583331b2d4c)
