### PR TITLE
Borrow APR and MarginPool's table column width refactor

### DIFF
--- a/src/hooks/useGetInstrumentsPools.ts
+++ b/src/hooks/useGetInstrumentsPools.ts
@@ -19,5 +19,9 @@ export const useGetInstrumentsPools = () => {
     return qPools?.data?.find((pool) => pool.id === instrumentId)?.lendApr;
   };
 
-  return { instrumentsPools: qPools?.data, getEarnAPR };
+  const getBorrowAPR = (instrumentId: string) => {
+    return qPools?.data?.find((pool) => pool.id === instrumentId)?.borrowApr;
+  };
+
+  return { instrumentsPools: qPools?.data, getEarnAPR, getBorrowAPR };
 };

--- a/src/pages/Explorer/components/MarginPool/Desktop/DesktopTable.tsx
+++ b/src/pages/Explorer/components/MarginPool/Desktop/DesktopTable.tsx
@@ -8,20 +8,23 @@ import UtilizationCircularProgress from '../../../../../components/CircularProgr
 import * as S from './styles';
 
 const DesktopTable = (props: IMarginPoolTable) => {
-  const { onChainAppState, getUSDValue, getEarnAPR } = props;
+  const { onChainAppState, getUSDValue, getEarnAPR, getBorrowAPR } = props;
   return (
     <S.Container>
       <S.Title>C3's Margin Pool</S.Title>
       <S.AssetInfo container>
-        <Grid item desktop={2}>
+        <Grid item desktop={1}>
           Asset
         </Grid>
-        <Grid item desktop={2} display="flex">
+        <Grid item desktop={1} display="flex">
           Utilization
           <TooltipInfo message="The percentage of the total supplied asset that's already been lent out" />
         </Grid>
         <Grid item desktop={1} display="flex">
           Earn APY
+        </Grid>
+        <Grid item desktop={1} display="flex">
+          Borrow APR
         </Grid>
         <Grid item desktop={3} display="flex">
           <S.ValorizedCompoundColumn container>
@@ -39,7 +42,6 @@ const DesktopTable = (props: IMarginPoolTable) => {
             </S.CompoundSubtitle>
           </S.ValorizedCompoundColumn>
         </Grid>
-        <Grid desktop={1}></Grid>
         <Grid item desktop={3} display="flex">
           <S.ValorizedCompoundColumn container>
             <S.CompoundTitle item>
@@ -73,21 +75,25 @@ const DesktopTable = (props: IMarginPoolTable) => {
           );
           const utilizationRate = liquidity !== 0 ? (borrowed / liquidity) * 100 : 0;
           const earnAPR = getEarnAPR(serverInstrument.instrument.id) || 0;
+          const borrowAPR = getBorrowAPR(serverInstrument.instrument.id) || 0;
 
           return (
             <S.Row key={serverInstrument.instrument.id}>
-              <S.AssetIconContainer item desktop={2}>
+              <S.AssetIconContainer item desktop={1}>
                 <S.IconContainer>
                   {getAssetIcon(serverInstrument.instrument.id)}
                 </S.IconContainer>
                 {serverInstrument.instrument.id}
               </S.AssetIconContainer>
-              <Grid item desktop={2} display="flex">
+              <Grid item desktop={1} display="flex">
                 <UtilizationCircularProgress value={utilizationRate} />
                 {formatNumber(utilizationRate)} %
               </Grid>
               <Grid item desktop={1} display="flex">
                 {formatApyNumber(earnAPR * 100)} %
+              </Grid>
+              <Grid item desktop={1} display="flex">
+                {formatApyNumber(borrowAPR * 100)} %
               </Grid>
               <Grid item desktop={3}>
                 <S.ValorizedInfoContainer container>
@@ -100,7 +106,6 @@ const DesktopTable = (props: IMarginPoolTable) => {
                   </S.RightAlignedGrid>
                 </S.ValorizedInfoContainer>
               </Grid>
-              <Grid desktop={1}></Grid>
               <Grid item desktop={3}>
                 <S.ValorizedInfoContainer container>
                   <S.RightAlignedGrid item desktop={6}>

--- a/src/pages/Explorer/components/MarginPool/Desktop/styles.ts
+++ b/src/pages/Explorer/components/MarginPool/Desktop/styles.ts
@@ -31,12 +31,12 @@ export const AssetInfo = styled(Grid)(({ theme }) => ({
   minHeight: '52px',
   maxHeight: '52px',
   padding: '4px 32px',
-  paddingRight: '128px',
   borderBottom: `1px solid ${theme.palette.primary.dark}`,
   color: theme.palette.text.primary,
   fontWeight: '500',
   display: 'flex',
   alignItems: 'center',
+  columnGap: '2%',
 }));
 
 export const Row = styled(Grid)(({ theme }) => ({
@@ -44,14 +44,16 @@ export const Row = styled(Grid)(({ theme }) => ({
   minHeight: '46px',
   maxHeight: '46px',
   padding: '8px 32px',
-  paddingRight: '128px',
   borderBottom: `1px solid ${theme.palette.primary.dark}`,
   display: 'flex',
   alignItems: 'center',
+  columnGap: '2%',
+  width: 'calc(100% + 4px)',
 }));
 
 export const ScrollableContent = styled('div')(() => ({
   overflowY: 'auto',
+  overflowX: 'hidden',
   height: 'calc(100% - 120px)',
   '&::-webkit-scrollbar': {
     width: '4px',
@@ -73,6 +75,7 @@ export const ValorizedCompoundColumn = styled(Grid)(({ theme }) => ({
   justifyContent: 'space-between',
   height: '100%',
   gap: '4px',
+  padding: '0 10px',
 }));
 
 export const CompoundTitle = styled(Grid)(({ theme }) => ({
@@ -95,7 +98,7 @@ export const CompoundSubtitle = styled(Grid)(({ theme }) => ({
 export const ValorizedInfoContainer = styled(Grid)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  padding: '0 8px',
+  padding: '0 18px',
 }));
 
 export const RightAlignedGrid = styled(Grid)(({ theme }) => ({

--- a/src/pages/Explorer/components/MarginPool/MarginPool.tsx
+++ b/src/pages/Explorer/components/MarginPool/MarginPool.tsx
@@ -12,7 +12,7 @@ import { useGetInstrumentsPools } from '../../../../hooks/useGetInstrumentsPools
 const MarginPool = (props: IMarginPool) => {
   const { onChainAppState } = props;
   const { getUSDValue } = usePrices();
-  const { getEarnAPR } = useGetInstrumentsPools();
+  const { getEarnAPR, getBorrowAPR } = useGetInstrumentsPools();
 
   const windowSize = useWindowSize();
   const isMobile = useMemo(
@@ -27,12 +27,14 @@ const MarginPool = (props: IMarginPool) => {
           onChainAppState={onChainAppState}
           getUSDValue={getUSDValue}
           getEarnAPR={getEarnAPR}
+          getBorrowAPR={getBorrowAPR}
         />
       ) : (
         <DesktopTable
           onChainAppState={onChainAppState}
           getUSDValue={getUSDValue}
           getEarnAPR={getEarnAPR}
+          getBorrowAPR={getBorrowAPR}
         />
       )}
     </>

--- a/src/pages/Explorer/components/MarginPool/Mobile/MobileTable.tsx
+++ b/src/pages/Explorer/components/MarginPool/Mobile/MobileTable.tsx
@@ -7,7 +7,7 @@ import UtilizationCircularProgress from '../../../../../components/CircularProgr
 import * as S from './styles';
 
 const MobileTable = (props: IMarginPoolTable) => {
-  const { onChainAppState, getUSDValue, getEarnAPR } = props;
+  const { onChainAppState, getUSDValue, getEarnAPR, getBorrowAPR } = props;
   return (
     <S.Container>
       <S.Title>C3's Margin Pool</S.Title>
@@ -27,6 +27,7 @@ const MobileTable = (props: IMarginPoolTable) => {
           );
           const utilizationRate = liquidity !== 0 ? (borrowed / liquidity) * 100 : 0;
           const earnAPR = getEarnAPR(serverInstrument.instrument.id) || 0;
+          const borrowAPR = getBorrowAPR(serverInstrument.instrument.id) || 0;
 
           return (
             <S.Card container key={serverInstrument.instrument.id}>
@@ -57,6 +58,14 @@ const MobileTable = (props: IMarginPoolTable) => {
                 </S.Item>
                 <S.Item item gap="4px">
                   {formatApyNumber(earnAPR * 100)} %
+                </S.Item>
+              </S.Row>
+              <S.Row container justifyContent="space-between">
+                <S.Item item _isTitle>
+                  Borrow APR
+                </S.Item>
+                <S.Item item gap="4px">
+                  {formatApyNumber(borrowAPR * 100)} %
                 </S.Item>
               </S.Row>
 

--- a/src/pages/Explorer/components/MarginPool/interfaces.ts
+++ b/src/pages/Explorer/components/MarginPool/interfaces.ts
@@ -7,6 +7,7 @@ interface IMarginPool {
 interface IMarginPoolTable extends IMarginPool {
   getUSDValue: (instrumentId: string, amount: number) => number;
   getEarnAPR: (instrumentId: string) => number | undefined;
+  getBorrowAPR: (instrumentId: string) => number | undefined;
 }
 
 export type { IMarginPool, IMarginPoolTable };


### PR DESCRIPTION
Added Borrow APR column in Margin Pool table
![Screenshot from 2024-04-26 10-57-05](https://github.com/c3exchange/c3-scan/assets/158588059/957cae2b-2d96-46d3-92ce-4803f9fd8278)
